### PR TITLE
PCH (Pre Compiled Heades) support

### DIFF
--- a/ThemidaProject/Devirt/deobf.cpp
+++ b/ThemidaProject/Devirt/deobf.cpp
@@ -1,14 +1,9 @@
-#include <Windows.h>
-#include <vector>
-#include <stdexcept>
-
-#include <zasm/formatter/formatter.hpp>
+#include "pch.h"
 
 #include "deobf.h"
 #include "../emulator/emu.h"
 #include "../utils/Utils.h"
 #include "../utils/Logger.h"
-
 #include "../callbacks/callbacks.h"
 
 
@@ -20,7 +15,6 @@ BasicBlock* deobf::handleBBIntersection(uintptr_t address)
 		return nullptr;
 
 	auto& instructions = foundBasicBlock->instructions;
-
 
 	std::list<Instruction>::iterator foundIt;
 	for (auto it = instructions.begin(); it != instructions.end();it++) {
@@ -38,7 +32,6 @@ BasicBlock* deobf::handleBBIntersection(uintptr_t address)
 		throw std::runtime_error("It means that ");
 
 	return foundBasicBlock;
-
 }
 
 void deobf::transverseBlock(uintptr_t rva,BasicBlock* bb)
@@ -51,7 +44,7 @@ void deobf::transverseBlock(uintptr_t rva,BasicBlock* bb)
 	   printf("Visited address 0x%llx\n", m_cpu->getEip());
 	   BasicBlock* labelBB = handleBBIntersection(m_cpu->getEip());
 	   if (!labelBB)
-		   throw std::runtime_error("What ???Fatal error");
+		   throw std::runtime_error("What ??? Fatal error");
 
 	   bb->pass1= labelBB;
 	   return;

--- a/ThemidaProject/Devirt/deobf.h
+++ b/ThemidaProject/Devirt/deobf.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include "../Optimization/Optimizer.h"
 
 class EmulatorCPU;
@@ -16,7 +17,7 @@ private:
 	void transverseBlock(uintptr_t rva, BasicBlock* bb);
 	BasicBlock* handleBBIntersection(uintptr_t address);
 public:
-	deobf(EmulatorCPU* cpu_, PE* pe) : m_cpu(cpu_), m_pe(pe), optimizer(new Optimizer()) {}
+	deobf(EmulatorCPU* cpu_, PE* pe=0) : m_cpu(cpu_), m_pe(pe), optimizer(new Optimizer()) {}
 
 	void run(uintptr_t);
 

--- a/ThemidaProject/Instruction/Instruction.cpp
+++ b/ThemidaProject/Instruction/Instruction.cpp
@@ -1,4 +1,4 @@
-#include <Windows.h>
+#include "pch.h"
 
 #include "Instruction.h"
 

--- a/ThemidaProject/Instruction/Instruction.h
+++ b/ThemidaProject/Instruction/Instruction.h
@@ -1,9 +1,10 @@
 #pragma once
-#include <vector>
-#include <Windows.h>
-#include <zasm/zasm.hpp>
-#include <list>
+
+#include "../emulator/emu.h"
+
 inline uintptr_t bbCount = 0;
+
+
 class BaseOperand {
 private:
 	zasm::Operand operand;

--- a/ThemidaProject/Optimization/BaseOptimization.cpp
+++ b/ThemidaProject/Optimization/BaseOptimization.cpp
@@ -1,1 +1,3 @@
+#include "pch.h"
+
 #include "BaseOptimization.h"

--- a/ThemidaProject/Optimization/BaseOptimization.h
+++ b/ThemidaProject/Optimization/BaseOptimization.h
@@ -1,6 +1,4 @@
 #pragma once
-#include <list>
-#include <zasm/zasm.hpp>
 
 #include "../Instruction/Instruction.h"
 

--- a/ThemidaProject/Optimization/Helpers/HelpersIterations.cpp
+++ b/ThemidaProject/Optimization/Helpers/HelpersIterations.cpp
@@ -1,9 +1,10 @@
-#include <stdexcept>
+#include "pch.h"
 
 #include "HelpersIterations.h"
 #include "../../Instruction/Instruction.h"
-#include "../../utils/Logger.h"
 #include "../../utils/Utils.h"
+#include "../../utils/Logger.h"
+
 
 int64_t calculateSubAdd(std::vector<zasm::InstructionDetail > instructions) {
     int64_t result = 0;

--- a/ThemidaProject/Optimization/Helpers/HelpersIterations.h
+++ b/ThemidaProject/Optimization/Helpers/HelpersIterations.h
@@ -1,7 +1,4 @@
 #pragma once
-#include <zasm/zasm.hpp>
-#include <vector>
-#include <list>
 
 class Instruction; 
 

--- a/ThemidaProject/Optimization/Optimizer.cpp
+++ b/ThemidaProject/Optimization/Optimizer.cpp
@@ -1,12 +1,12 @@
+#include "pch.h"
+
 #include "Optimizer.h"
 #include "BaseOptimization.h"
-
 #include "SimplifyConstantFolding.h"
 #include "SimplifyDeadcodeElimination.h"
 #include "SimplifyStackOperation.h"
 #include "SimplifyMbaOperation.h"
 #include "../Instruction/Instruction.h"
-
 #include "../utils/Utils.h"
 
 void Optimizer::runMbaPasses(BasicBlock* bb)

--- a/ThemidaProject/Optimization/Optimizer.h
+++ b/ThemidaProject/Optimization/Optimizer.h
@@ -1,7 +1,4 @@
 #pragma once
-#include <list>
-#include <zasm/zasm.hpp>
-#include <unordered_set>
 
 #include "../Instruction/Instruction.h"
 

--- a/ThemidaProject/Optimization/SimplifyConstantFolding.cpp
+++ b/ThemidaProject/Optimization/SimplifyConstantFolding.cpp
@@ -1,11 +1,12 @@
-#include <cmath>
+#include "pch.h"
 
 #include "SimplifyConstantFolding.h"
+#include "Helpers/HelpersIterations.h"
 #include "../Instruction/Instruction.h"
-#include "./Helpers/HelpersIterations.h"
 #include "../utils/Utils.h"
-#include "../emulator/emu.h"
 #include "../utils/Logger.h"
+#include "../emulator/emu.h"
+
 
 //Read constant folding
 static bool foldConstantRead(std::list<Instruction>::iterator it, std::list<Instruction>& instructions) {

--- a/ThemidaProject/Optimization/SimplifyConstantFolding.h
+++ b/ThemidaProject/Optimization/SimplifyConstantFolding.h
@@ -1,6 +1,6 @@
 #pragma once
-#include "BaseOptimization.h"
 
+#include "BaseOptimization.h"
 #include "../Instruction/Instruction.h"
 
 class SimplifyConstantFolding : public BaseOptimization 

--- a/ThemidaProject/Optimization/SimplifyDeadcodeElimination.cpp
+++ b/ThemidaProject/Optimization/SimplifyDeadcodeElimination.cpp
@@ -1,7 +1,9 @@
+#include "pch.h"
+
 #include "SimplifyDeadcodeElimination.h"
+#include "Helpers/HelpersIterations.h"
 #include "../Instruction/Instruction.h"
 #include "../utils/Utils.h"
-#include "./Helpers/HelpersIterations.h"
 #include "../utils/Logger.h"
 
 //mov rbx,rbx

--- a/ThemidaProject/Optimization/SimplifyDeadcodeElimination.h
+++ b/ThemidaProject/Optimization/SimplifyDeadcodeElimination.h
@@ -1,6 +1,6 @@
 #pragma once
-#include "BaseOptimization.h"
 
+#include "BaseOptimization.h"
 #include "../Instruction/Instruction.h"
 
 class SimplifyDeadcodeElimination : public BaseOptimization

--- a/ThemidaProject/Optimization/SimplifyMbaOperation.cpp
+++ b/ThemidaProject/Optimization/SimplifyMbaOperation.cpp
@@ -1,5 +1,7 @@
+#include "pch.h"
+
 #include "SimplifyMbaOperation.h"
-#include "./Helpers/HelpersIterations.h"
+#include "Helpers/HelpersIterations.h"
 #include "../utils/Utils.h"
 #include "../utils/Logger.h"
 

--- a/ThemidaProject/Optimization/SimplifyMbaOperation.h
+++ b/ThemidaProject/Optimization/SimplifyMbaOperation.h
@@ -1,6 +1,6 @@
 #pragma once
-#include "BaseOptimization.h"
 
+#include "BaseOptimization.h"
 #include "../Instruction/Instruction.h"
 
 class SimplifyMbaOperation : public BaseOptimization

--- a/ThemidaProject/Optimization/SimplifyStackOperation.cpp
+++ b/ThemidaProject/Optimization/SimplifyStackOperation.cpp
@@ -1,7 +1,10 @@
+#include "pch.h"
+
 #include "SimplifyStackOperation.h"
+#include "Helpers/HelpersIterations.h"
 #include "../utils/Utils.h"
-#include "./Helpers/HelpersIterations.h"
 #include "../utils/Logger.h"
+
 
 //Simplify push reg,pop reg -> mov
 static bool PushPopToMove(std::list<Instruction>::iterator it, std::list<Instruction>& instructions) {

--- a/ThemidaProject/Optimization/SimplifyStackOperation.h
+++ b/ThemidaProject/Optimization/SimplifyStackOperation.h
@@ -1,6 +1,6 @@
 #pragma once
-#include "BaseOptimization.h"
 
+#include "BaseOptimization.h"
 #include "../Instruction/Instruction.h"
 
 class SimplifyStackOperation : public BaseOptimization

--- a/ThemidaProject/PE/PE.cpp
+++ b/ThemidaProject/PE/PE.cpp
@@ -1,6 +1,7 @@
+#include "pch.h"
+
 #include "PE.h"
-
-
+#include "../emulator/emu.h"
 
 IMAGE_DOS_HEADER* PE::GetDosHeader()
 {
@@ -74,7 +75,6 @@ bool PE::MapFile(std::vector<BYTE>& data)
 #define RELOC_FLAG RELOC_FLAG32
 #endif 
 
-#include "../emulator/emu.h"
 bool PE::MapRelocations()
 {
     const uintptr_t LocationDelta = EmulatorCPU::baseImage - GetNtHeader()->OptionalHeader.ImageBase;

--- a/ThemidaProject/PE/PE.h
+++ b/ThemidaProject/PE/PE.h
@@ -1,7 +1,4 @@
 #pragma once
-#include <Windows.h>
-#include <vector>
-#include <winternl.h>
 
 class PE
 {

--- a/ThemidaProject/ThemidaProject.cpp
+++ b/ThemidaProject/ThemidaProject.cpp
@@ -1,15 +1,12 @@
-﻿#include <iostream>
-#include <map>
+﻿#include "pch.h"
 
-#include  "Utils/Utils.h"
+#include "Utils/Utils.h"
+#include "Utils/Logger.h"
 #include "emulator/emu.h"
 #include "PE/PE.h"
-
-#include "Utils/Logger.h"
-#include "./Devirt/deobf.h"
+#include "Devirt/deobf.h"
 
 
-// Функция для парсинга аргументов командной строки
 std::map<std::string, std::string> parseArguments(int argc, char* argv[]) {
     std::map<std::string, std::string> arguments;
 
@@ -36,19 +33,18 @@ void printHelp() {
         << "  -b <path>      Path to binary file (required)\n"
         << "  -o <path>      Path to log file (default: D:\\log.txt)\n"
         << "  -rva <rva>     RVA of obfuscated function (hex or decimal)\n"
-        << "  -sectionStart <address> Start address of section (hex or decimal)\n"
-        << "  -sectionSize <size>     Size of section (hex or decimal)\n"
+        << "  -sectionStart  <address> Start address of section (hex or decimal)\n"
+        << "  -sectionSize   <size>    Size of section (hex or decimal)\n"
         << "  -help          Show this help message\n";
 }
 
 int main(int argc, char* argv[])
 {
-    // Парсинг аргументов командной строки
     auto args = parseArguments(argc, argv);
 
     if (args.count("-help")) {
         printHelp();
-        return 0;
+        return EXIT_SUCCESS;
     }
 
     if(!args.count("-rva")) {

--- a/ThemidaProject/ThemidaProject.vcxproj
+++ b/ThemidaProject/ThemidaProject.vcxproj
@@ -113,6 +113,8 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -149,6 +151,9 @@
     <ClCompile Include="Optimization\SimplifyConstantFolding.cpp" />
     <ClCompile Include="Optimization\SimplifyDeadcodeElimination.cpp" />
     <ClCompile Include="Optimization\SimplifyMbaOperation.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="PE\PE.cpp" />
     <ClCompile Include="Optimization\SimplifyStackOperation.cpp" />
     <ClCompile Include="ThemidaProject.cpp" />
@@ -166,6 +171,7 @@
     <ClInclude Include="Optimization\SimplifyConstantFolding.h" />
     <ClInclude Include="Optimization\SimplifyDeadcodeElimination.h" />
     <ClInclude Include="Optimization\SimplifyMbaOperation.h" />
+    <ClInclude Include="pch.h" />
     <ClInclude Include="PE\PE.h" />
     <ClInclude Include="Optimization\SimplifyStackOperation.h" />
     <ClInclude Include="utils\Logger.h" />

--- a/ThemidaProject/ThemidaProject.vcxproj
+++ b/ThemidaProject/ThemidaProject.vcxproj
@@ -71,7 +71,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>$(ZASM)\build\_deps\zydis-src\dependencies\zycore\include;$(ZASM)\build\_deps\zydis-src\include;$(ZASM)\zasm\include;$(IncludePath)</IncludePath>
+    <IncludePath>$(ZASM)\build\_deps\zydis-src\dependencies\zycore\include;$(ZASM)\build\_deps\zydis-src\include;$(ZASM)\zasm\include;.;$(IncludePath)</IncludePath>
     <LibraryPath>$(ZASM)\build\_deps\zydis-build\Debug;$(ZASM)\build\Debug;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/ThemidaProject/ThemidaProject.vcxproj.filters
+++ b/ThemidaProject/ThemidaProject.vcxproj.filters
@@ -60,6 +60,9 @@
     <ClCompile Include="Optimization\SimplifyMbaOperation.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="pch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="emulator\emu.h">
@@ -102,6 +105,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Optimization\SimplifyMbaOperation.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="pch.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/ThemidaProject/callbacks/callbacks.cpp
+++ b/ThemidaProject/callbacks/callbacks.cpp
@@ -1,14 +1,15 @@
-#include <format>
+#include "pch.h"
 
-
-#include "../emulator/emu.h"
 #include "callbacks.h"
+#include "../emulator/emu.h"
 #include "../utils/Utils.h"
 #include "../utils/Logger.h"
 #include "../Instruction/Instruction.h"
 
-bool traceCallback(EmulatorCPU* cpu, uintptr_t address, zasm::InstructionDetail instruction_,
-    void* user_data) {
+bool traceCallback(EmulatorCPU* cpu, uintptr_t address, zasm::InstructionDetail& instruction_, void* user_data)
+{
+    //if (countGlobal == 638 || countGlobal == 632)
+    //    printf("");
 
     BasicBlock* foundBasicBlock = FindAddressBasicBlock(globals::bb, address);
 
@@ -31,8 +32,6 @@ bool traceCallback(EmulatorCPU* cpu, uintptr_t address, zasm::InstructionDetail 
 
     auto& operands = instruction.getOperands();
 
-
-
     for (int i = 0; i < operands.size(); i++) {
         auto& op = operands[i];
 
@@ -45,7 +44,6 @@ bool traceCallback(EmulatorCPU* cpu, uintptr_t address, zasm::InstructionDetail 
 
         op->setOperandAccess(instruction_.getOperandAccess(i));
     }
-
 
     bb->instructions.push_back(instruction);
 

--- a/ThemidaProject/callbacks/callbacks.h
+++ b/ThemidaProject/callbacks/callbacks.h
@@ -1,13 +1,7 @@
 #pragma once
-#include <zasm/zasm.hpp>
-
-#include <Windows.h>
-
 
 class EmulatorCPU;
 class Instruction;
 struct BasicBlock;
 
-
-bool traceCallback(EmulatorCPU* cpu, uintptr_t address, zasm::InstructionDetail instruction,
-    void* user_data);
+bool traceCallback(EmulatorCPU* cpu, uintptr_t address, zasm::InstructionDetail& instruction, void* user_data);

--- a/ThemidaProject/emulator/emu.cpp
+++ b/ThemidaProject/emulator/emu.cpp
@@ -1,17 +1,9 @@
-#include <limits>
-#include <bit>
-#include <immintrin.h>
-
-#include <zasm/formatter/formatter.hpp>
+#include "pch.h"
 
 #include "emu.h"
-
-
-
 #include "../Utils/Utils.h"
-#include "../PE/PE.h"
-#include <format>
 #include "../Utils/Logger.h"
+#include "../PE/PE.h"
 
 void EmulatorCPU::PushValue(uintptr_t value)
 {
@@ -794,7 +786,6 @@ namespace std
 			((value << 56) & 0xFF00000000000000);
 	}
 #else
-#include <bit>
 	using std::byteswap;
 #endif
 }

--- a/ThemidaProject/emulator/emu.h
+++ b/ThemidaProject/emulator/emu.h
@@ -1,19 +1,11 @@
 #pragma once
-#include <Windows.h>
-#include <array>
-#include <vector>
-#include <functional>
-
-#include <zasm/zasm.hpp>
-
-class EmulatorCPU;
 
 
 class EmulatorCPU
 {
 private:
 	using callbackFunction = bool(*)(EmulatorCPU* cpu_, uintptr_t address, 
-		zasm::InstructionDetail curInstr, void* userData);
+		zasm::InstructionDetail& curInstr, void* userData);
 
 	struct callbackStruct {
 		void* callback_data;

--- a/ThemidaProject/pch.cpp
+++ b/ThemidaProject/pch.cpp
@@ -1,0 +1,5 @@
+// pch.cpp: source file corresponding to pre-compiled header; necessary for compilation to succeed
+
+#include "pch.h"
+
+// In general, ignore this file, but keep it around if you are using pre-compiled headers.

--- a/ThemidaProject/pch.h
+++ b/ThemidaProject/pch.h
@@ -8,11 +8,13 @@
 #include <vector>
 #include <list>
 #include <map>
+#include <unordered_set>
 #include <format>
 #include <stdexcept>
 #include <bit>
 #include <functional>
 
+#include <fstream>
 #include <iostream>
 #include <cmath>
 #include <limits>

--- a/ThemidaProject/pch.h
+++ b/ThemidaProject/pch.h
@@ -1,0 +1,29 @@
+#ifndef PCH_H
+#define PCH_H
+
+// add headers that you want to pre-compile here
+
+#include <string>
+#include <array>
+#include <vector>
+#include <list>
+#include <map>
+#include <format>
+#include <stdexcept>
+#include <bit>
+#include <functional>
+
+#include <iostream>
+#include <cmath>
+#include <limits>
+
+#include <inttypes.h>
+#include <immintrin.h>
+
+#include <windows.h>
+
+#include <zasm/zasm.hpp>
+#include <zasm/formatter/formatter.hpp>
+
+
+#endif //PCH_H

--- a/ThemidaProject/utils/Logger.cpp
+++ b/ThemidaProject/utils/Logger.cpp
@@ -1,17 +1,20 @@
+#include "pch.h"
+
 #include "Logger.h"
 
 Logger::Logger(const char* path)
+    : m_path(path)
 {
     hFile = CreateFileA(
-        path,                // имя файла
-        GENERIC_WRITE,           // возможность записи
-        0,                       // общий доступ отключен
-        NULL,                    // атрибуты безопасности по умолчанию
-        CREATE_ALWAYS,           // создание нового файла, если файла нет, или перезапись существующего
-        FILE_ATTRIBUTE_NORMAL,   // обычный файл
-        NULL                     // шаблонные файлы не используются
+        path,
+        GENERIC_WRITE,
+        0,
+        NULL,
+        CREATE_ALWAYS,
+        FILE_ATTRIBUTE_NORMAL,
+        NULL
     );
-    // Проверка, удалось ли создать файл
+
     if (hFile == INVALID_HANDLE_VALUE) {
         printf("unable to createfile\n");
         exit(0);
@@ -22,11 +25,11 @@ void Logger::log(const std::string& data)
 {
     DWORD bytesWritten;
     bool writeSuccess = WriteFile(
-        hFile,                  // дескриптор файла
-        data.c_str(),           // буфер данных для записи
-        data.length(),          // количество байтов для записи
-        &bytesWritten,          // количество записанных байтов
-        NULL                    // асинхронная запись не используется
+        hFile,
+        data.c_str(),
+        (DWORD)data.length(),
+        &bytesWritten,
+        NULL
     );
 
     if (!writeSuccess)

--- a/ThemidaProject/utils/Logger.h
+++ b/ThemidaProject/utils/Logger.h
@@ -1,7 +1,5 @@
 #pragma once
-#include <fstream>
-#include <string>
-#include <Windows.h>
+
 
 class Logger
 {

--- a/ThemidaProject/utils/Utils.cpp
+++ b/ThemidaProject/utils/Utils.cpp
@@ -1,14 +1,9 @@
+#include "pch.h"
+
 #include "Utils.h"
-
-
-#include <fstream>
-#include <format>
-#include <unordered_set>
-#include <zasm/formatter/formatter.hpp>
-
+#include "Logger.h"
 #include "../Instruction/Instruction.h"
 #include "../emulator/emu.h"
-#include "Logger.h"
 
 
 bool ReadFile(const std::string& path, std::vector<BYTE>& bin)

--- a/ThemidaProject/utils/Utils.h
+++ b/ThemidaProject/utils/Utils.h
@@ -1,10 +1,4 @@
 #pragma once
-#include <Windows.h>
-
-#include <string>
-#include <vector>
-#include <variant>
-#include <zasm/zasm.hpp>
 
 #include "../emulator/emu.h"
 
@@ -32,14 +26,13 @@ namespace globals {
 }
 
 
-
-
 enum class ReasonStop {
     JCC,
     UNCOND_TRANSFER,
     EXIT_EXTERNAL,
     VISITED
 };
+
 inline ReasonStop reasonStop;
 
 bool ReadFile(const std::string& path, std::vector<BYTE>& bin);


### PR DESCRIPTION
Goal: Increase compilation time up to 5 times
added pch module that compiles one and captures all the system headers
fine tuned compiler options to create pch for a single module (pch.cpp)
rest of modules are just re-using created cache